### PR TITLE
Projects storage update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 
 .PHONY: run
 run:
-	 cargo run --release -- --dev --tmp
+	 cargo run --release -- --dev --tmp -lruntime=debug
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ There are 2 options:
 1. Use [Substrate Front End Template](https://github.com/substrate-developer-hub/substrate-front-end-template). Follow instrations in the repo.
 2. Use this [link](https://polkadot.js.org/apps/#/extrinsics?rpc=ws://127.0.0.1:9944) to open the Polkadot JS Apps UI and automatically configure the UI to connect to the local node.
 
+## Tools 
+
+1. [Utilities and libraries](https://polkadot.js.org/docs/) for interacting with the Polkadot/Parachains/Substrate network from JavaScript
+2. [Substrate Utilities](https://www.shawntabrizi.com/substrate-js-utilities/)
+
 ### Single-Node Development Chain
 
 This command will start the single-node development chain with persistent state:

--- a/pallets/deip-projects/src/lib.rs
+++ b/pallets/deip-projects/src/lib.rs
@@ -1,14 +1,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-    codec::{Decode, Encode}, debug,
+    codec::{Decode, Encode}, debug, ensure,
     decl_module, decl_storage, decl_event, decl_error, 
     StorageMap
 };
 use frame_system::{ self as system, ensure_signed };
 use sp_std::vec::Vec;
+use sp_std::vec;
 use sp_runtime::{ RuntimeDebug };
 use sp_core::{ H160 };
+
+
+/// A maximum number of Domains. When domains reaches this number, no new domains can be added.
+pub const MAX_DOMAINS: u32 = 100;
 
 /// Configure the pallet by specifying the parameters and types on which it depends.
 pub trait Trait: frame_system::Trait {
@@ -17,13 +22,18 @@ pub trait Trait: frame_system::Trait {
 }
 
 #[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]
-pub struct Project<Hash, H160> {
+pub struct Project<Hash, H160, Domain, AccountId> {
     is_private: bool,
     external_id: H160,
     team: H160,
     description: Hash,
+    domains: Vec<Domain>,
+    members: Vec<AccountId>
     
 }
+
+type Domain = H160;
+type ProjectOf<T> = Project<<T as system::Trait>::Hash, H160, Domain, <T as system::Trait>::AccountId>;
 
 // Pallets use events to inform users when important changes are made.
 // Event documentation should end with an array that provides descriptive names for parameters.
@@ -32,22 +42,37 @@ decl_event! {
     pub enum Event<T> 
     where 
         AccountId = <T as frame_system::Trait>::AccountId,
-        Hash = <T as system::Trait>::Hash
+        // Hash = <T as system::Trait>::Hash,
+        Project = ProjectOf<T>
     {
         /// Event emitted when a project has been created. [BelongsTo, Project]
-        ProjectCreated(AccountId, Project<Hash, H160>),
+        ProjectCreated(AccountId, Project),
         /// Event emitted when a project is removed by the owner. [BelongsTo, Project]
-        ProjectRemoved(AccountId, Project<Hash, H160>),
+        ProjectRemoved(AccountId, Project),
+
+        /// Added a domain. [Creator, Domain]
+		DomainAdded(AccountId, Domain),
     }
 }
 
 // Errors inform users that something went wrong.
 decl_error! {
     pub enum Error for Module<T: Trait> {
+        // ==== Projects ===
+        
         /// The project does not exist, so it cannot be removed.
         NoSuchProject,
         /// The project is created by another account, so caller can't remove it.
         NotProjectOwner,
+        /// Cannot add domain into the porject because this domain not exists
+        DomainNotExists,
+
+        // ==== Domains ===
+        
+        /// Cannot add another domain because the limit is already reached
+        DomianLimitReached,
+        /// Cannot add domain because this domain is already a exists
+        DomainAlreadyExists,     
     }
 }
 
@@ -57,7 +82,13 @@ decl_storage! {
     trait Store for Module<T: Trait> as DeipProjects {
         /// The storage item for our projects.
         /// It maps a projects to the user who created the them.
-        Projects get(fn projects): map hasher(blake2_128_concat) T::AccountId => Vec<Project<T::Hash, H160>>;
+        Projects get(fn projects): map hasher(blake2_128_concat) T::AccountId => Vec<ProjectOf<T>>;
+
+        // The set of all Domains.
+        Domains get(fn domains): map hasher(blake2_128_concat) Domain => ();
+        // The total number of domains stored in the map.
+        // Because the map does not store its size, we must store it separately
+        DomainCount: u32;
     }
 }
 
@@ -72,51 +103,48 @@ decl_module! {
         // Events must be initialized if they are used by the pallet.
         fn deposit_event() = default;
 
-        /// Allow a user to create project.
-        #[weight = 10_000]
-        fn create_project(origin, is_private: bool, external_id: H160, team: H160, description: T::Hash) {
-            // Check that the extrinsic was signed and get the signer.
-            // This function will return an error if the extrinsic is not signed.
-            // https://substrate.dev/docs/en/knowledgebase/runtime/origin
-            let account = ensure_signed(origin)?;
-
-            let mut projects = Projects::<T>::get(&account);
- 
-            let project = Project {
-                is_private,
-                external_id,
-                team,
-                description
-            };
-
-            // Modify Projects List via adding new Project
-            projects.push(project);
-
-            // Store the projects related to accountt
-            Projects::<T>::insert(&account, projects);
-
-            // Emit an event that the project was created.
-            // Self::deposit_event(RawEvent::ProjectCreated(account, project));
-        }
-        
         /// Allow a user to create full project.
         #[weight = 10_000]
-        fn create_project_full(origin, project: Project<T::Hash, H160>) {
+        fn create_project_full(origin, project: ProjectOf<T>) {
             // Check that the extrinsic was signed and get the signer.
             // This function will return an error if the extrinsic is not signed.
             // https://substrate.dev/docs/en/knowledgebase/runtime/origin
             let account = ensure_signed(origin)?;
+            
+            for domain in &project.domains {
+                ensure!(Domains::contains_key(&domain), Error::<T>::DomainNotExists);
+            }
 
             let mut projects = Projects::<T>::get(&account);
 
             // Modify Projects List via adding new Project
-            projects.push(project);
+            projects.push(project.clone());
 
-            // Store the projects related to accountt
+            // Store the projects related to account
             Projects::<T>::insert(&account, projects);
 
             // Emit an event that the project was created.
-            // Self::deposit_event(RawEvent::ProjectCreated(account, project));
+            Self::deposit_event(RawEvent::ProjectCreated(account, project));
         }
+        
+        /// Allow a user to create domains.
+        #[weight = 10_000]
+        fn add_domain(origin, doamin: Domain) {
+            let account = ensure_signed(origin)?;
+        
+            let domain_count = DomainCount::get();
+            ensure!(domain_count < MAX_DOMAINS, Error::<T>::DomianLimitReached);
+        
+            // We don't want to add duplicate doamins, so we check whether the potential new
+            // domain is already present in the list. Because the domains is stored as a hash
+            // map this check is constant time O(1)
+            ensure!(!Domains::contains_key(&doamin), Error::<T>::DomainAlreadyExists);
+        
+            // Insert the new domin and emit the event
+            Domains::insert(&doamin, ());
+            DomainCount::put(domain_count + 1); // overflow check not necessary because of maximum
+            Self::deposit_event(RawEvent::DomainAdded(account, doamin));
+        }
+
     }
 }

--- a/pallets/deip-projects/src/polkadot-js-types.json
+++ b/pallets/deip-projects/src/polkadot-js-types.json
@@ -1,9 +1,10 @@
 {
     "Domain": "H160",
+    "ProjectId": "H160",
     "Project": {
       "is_private": "bool",
-      "external_id": "H160",
-      "team": "H160",
+      "external_id": "ProjectId",
+      "team": "AccountId",
       "description": "Hash",
       "domains": "Vec<Domain>",
       "members": "Vec<AccountId>"

--- a/pallets/deip-projects/src/polkadot-js-types.json
+++ b/pallets/deip-projects/src/polkadot-js-types.json
@@ -1,0 +1,12 @@
+{
+    "Domain": "H160",
+    "Project": {
+      "is_private": "bool",
+      "external_id": "H160",
+      "team": "H160",
+      "description": "Hash",
+      "domains": "Vec<Domain>",
+      "members": "Vec<AccountId>"
+    },
+    "ProjectOf": "Project"
+  }


### PR DESCRIPTION
### Updates: 

- Domain entity added
- Projects storage structure changed
- Added uniqueness by projects
- Added the possibility to update the project

### **Projects Storage Structure** 

**Project Type:**

```rust
pub struct Project<Hash, AccountId> {
    is_private: bool,
    external_id: ProjectId,
    team_id: AccountId,
    description: Hash,
    domains: Vec<Domain>,
    members: Vec<AccountId>
    
}
```

**Projects** — Vector (Array) of Tuples containing ProjectId and AccountIt (attitude of the project to the team). Analogy of a table with two fields. Uniqueness is achieved through this collection and controled by our code.

**ProjectMap** — [HashMap](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.StorageMap.html)  from ProjectId to Project 


### **Quering**

List of Project can be got by calling Projects Storage rpc API. Thus, having received list of Project IDs. Data of project can be recived via ProjectMap rpc API one by one.