### PR TITLE
Proof of Share 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,6 +3781,7 @@ version = "2.0.1"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-timestamp",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/pallets/deip/Cargo.toml
+++ b/pallets/deip/Cargo.toml
@@ -20,6 +20,7 @@ version = '1.3.4'
 
 [dependencies]
 frame-support = { default-features = false, version = '2.0.1' }
+pallet-timestamp = { default-features = false, version = '2.0.1' }
 frame-system = { default-features = false, version = '2.0.1' }
 sp-std = { default-features = false, version = '2.0.1' }
 sp-runtime = { version = '2.0.1', default-features = false }
@@ -37,5 +38,6 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'sp-std/std', 
+    'pallet-timestamp/std',
     'serde'
 ]

--- a/pallets/deip/src/lib.rs
+++ b/pallets/deip/src/lib.rs
@@ -44,7 +44,7 @@ impl Default for ProjectContentType {
 }
 
 /// Configure the pallet by specifying the parameters and types on which it depends.
-pub trait Trait: frame_system::Trait {
+pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
     /// Because this pallet emits events, it depends on the runtime's definition of an event.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 }
@@ -52,7 +52,11 @@ pub trait Trait: frame_system::Trait {
 pub type ProjectId = H160;
 pub type Domain = H160;
 pub type ProjectContentId = H160;
+pub type NdaId = H160;
+pub type NdaAccessRequestId = H160;
 pub type ProjectOf<T> = Project<<T as system::Trait>::Hash, <T as system::Trait>::AccountId>;
+pub type NdaOf<T> = Nda<<T as system::Trait>::Hash, <T as system::Trait>::AccountId, <T as pallet_timestamp::Trait>::Moment>;
+pub type NdaAccessRequestOf<T> = NdaAccessRequest<<T as system::Trait>::Hash, <T as system::Trait>::AccountId>;
 pub type ProjectContentOf<T> = ProjectContent<<T as system::Trait>::Hash, <T as system::Trait>::AccountId>;
 #[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]
 pub struct Project<Hash, AccountId> {
@@ -76,8 +80,27 @@ pub struct ProjectContent<Hash, AccountId> {
     references: Option<Vec<ProjectContentId>>
     
 }
+#[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]
+pub struct Nda<Hash, AccountId, Moment>  {
+    contract_creator: AccountId,
+    external_id: NdaId,
+    end_date: Moment,
+    start_date: Option<Moment>,
+    contract_hash: Hash,
+    parties: Vec<AccountId>,
+    projects: Vec<ProjectId>,
+}
 
-// Pallets use events to inform users when important changes are made.
+#[derive(Encode, Decode, Clone, Default, RuntimeDebug, PartialEq, Eq)]
+pub struct NdaAccessRequest<Hash, AccountId>  {
+    external_id: NdaAccessRequestId,
+    nda_external_id: NdaId,
+    requester: AccountId,
+    encrypted_payload_hash: Hash,
+    encrypted_payload_iv: Vec<u8>,
+}
+
+// Pallets use events to inform users when imporFtant changes are made.
 // Event documentation should end with an array that provides descriptive names for parameters.
 // https://substrate.dev/docs/en/knowledgebase/runtime/events
 decl_event! {
@@ -100,6 +123,13 @@ decl_event! {
        
         /// Event emitted when a project contnet has been created. [BelongsTo, ProjectContentId]
         ProjectContnetCreated(AccountId, ProjectContentId),
+
+        // ==== NDA ====
+       
+        /// Event emitted when a NDA has been created. [BelongsTo, NdaId]
+        NdaCreated(AccountId, NdaId),
+        /// Event emitted when a NDA Access request has been created. [BelongsTo, NdaAccessRequestId]
+        NdaAccessRequestCreated(AccountId, NdaAccessRequestId),
 
         /// Added a domain. [Creator, Domain]
 		DomainAdded(AccountId, Domain),
@@ -138,6 +168,19 @@ decl_error! {
         DomianLimitReached,
         /// Cannot add domain because this domain is already a exists
         DomainAlreadyExists,
+
+        // ==== NDA ====
+        
+        /// Cannot add a NDA because a NDA with this ID is already a exists.
+        NdaAlreadyExists,
+        NdaAccessRequestsAlreadyExists,
+        NoSuchNda,
+        NdaContractIsNotActiveYet,
+        NdaStartDateMustBeLaterOrEqualCurrentMoment,
+        NdaEndDateMustBeLaterCurrentMoment,
+        NdaStartDateMustBeLessThanEndDate,
+        TeamOfAllProjectsMustSpecifiedAsParty,
+
         
         
         // ==== General =====
@@ -157,6 +200,12 @@ decl_storage! {
 
         ProjectContentMap get(fn project_content_entity): double_map hasher(identity) ProjectId, hasher(identity) ProjectContentId => ProjectContentOf<T>;
         ProjectsContent get(fn project_content_list): Vec<(ProjectContentId, ProjectId, T::AccountId)>;
+
+        Ndas get(fn nda_list): Vec<(ProjectId, T::AccountId)>;
+        NdaMap get(fn nda): map hasher(identity) NdaId => NdaOf<T>;
+        
+        NdaAccessRequests get(fn nda_requests): Vec<NdaAccessRequestOf<T>>;
+        NdaAccessRequestMap get(fn nda_request): map hasher(identity) NdaAccessRequestId => NdaAccessRequestOf<T>;
 
         // The set of all Domains.
         Domains get(fn domains) config(): map hasher(blake2_128_concat) Domain => ();
@@ -280,6 +329,89 @@ decl_module! {
 
             // Emit an event that the content was created.
             Self::deposit_event(RawEvent::ProjectContnetCreated(account, content.external_id));
+        }
+
+        /// Allow a user to create NDA.
+        #[weight = 10_000]
+        fn create_project_nda(origin,  
+            external_id: NdaId,
+            end_date: T::Moment,
+            contract_hash: T::Hash,
+            maybe_start_date: Option<T::Moment>,
+            parties: Vec<T::AccountId>,
+            projects: Vec<ProjectId>
+        ) {
+            let mut projects = projects;
+            projects.dedup();
+            let contract_creator = ensure_signed(origin)?;
+            let timestamp = pallet_timestamp::Module::<T>::get();
+
+            ensure!(end_date > timestamp, Error::<T>::NdaEndDateMustBeLaterCurrentMoment);
+
+            if let Some(start_date) = maybe_start_date {
+                ensure!(start_date >= timestamp, Error::<T>::NdaStartDateMustBeLaterOrEqualCurrentMoment);
+                ensure!(end_date > start_date, Error::<T>::NdaStartDateMustBeLessThanEndDate);
+            }
+            
+            projects.iter()
+                .try_for_each(|id| -> DispatchResult {
+                    let project = ProjectMap::<T>::get(id);
+
+                    ensure!(!project.external_id.is_zero(), Error::<T>::NoSuchProject);
+                    ensure!(parties.contains(&project.team_id), Error::<T>::TeamOfAllProjectsMustSpecifiedAsParty);
+
+                    Ok(())
+                })?;
+
+            let mut nda_list = Ndas::<T>::get();
+
+            let index_to_insert_nda = nda_list.binary_search_by_key(&external_id, |&(external_id, ..)| external_id)
+                .err().ok_or(Error::<T>::NdaAlreadyExists)?;
+            
+               
+            let nda = Nda {
+                contract_creator: contract_creator.clone(),
+                external_id,
+                end_date,
+                start_date: maybe_start_date,
+                contract_hash,
+                parties,
+                projects
+            };
+            
+            nda_list.insert(index_to_insert_nda, (nda.external_id, contract_creator.clone()));
+            Ndas::<T>::put(nda_list);
+
+            NdaMap::<T>::insert(nda.external_id, nda);
+
+            // Emit an event that the NDA was created.
+            Self::deposit_event(RawEvent::NdaCreated(contract_creator, external_id));
+
+        }
+
+        /// Create request to access NDA content
+        #[weight = 10_000]
+        fn create_nda_content_access_request(origin, nda_request: NdaAccessRequestOf<T>) {
+            let account = ensure_signed(origin)?;
+            let timestamp = pallet_timestamp::Module::<T>::get();
+
+            let nda = NdaMap::<T>::get(nda_request.nda_external_id);
+            
+            ensure!(!nda.external_id.is_zero(), Error::<T>::NoSuchNda);
+            ensure!(nda.start_date <= Some(timestamp), Error::<T>::NdaContractIsNotActiveYet);
+
+            let mut nda_requests = NdaAccessRequests::<T>::get();
+
+            let index_to_insert_nda_request = nda_requests.binary_search_by_key(&nda_request.external_id, |&NdaAccessRequest {external_id, ..}| external_id)
+                .err().ok_or(Error::<T>::NdaAccessRequestsAlreadyExists)?;
+
+            nda_requests.insert(index_to_insert_nda_request, nda_request.clone());
+            NdaAccessRequests::<T>::put(nda_requests);
+
+            // Emit an event that the NDA was created.
+            Self::deposit_event(RawEvent::NdaAccessRequestCreated(account, nda_request.external_id));
+            
+
         }
         
         /// Allow a user to create domains.

--- a/pallets/deip/src/types.json
+++ b/pallets/deip/src/types.json
@@ -2,8 +2,28 @@
     "Domain": "H160",
     "ProjectId": "H160",
     "ProjectContentId": "H160",
+    "NdaAccessRequestId": "H160",
+    "NdaId": "H160",
+    "NdaOf": "Nda",
+    "NdaAccessRequestOf": "NdaAccessRequest",
     "ProjectOf": "Project",
     "ProjectContentOf": "ProjectContent",
+    "Nda": {
+      "contract_creator": "AccountId",
+      "external_id": "NdaId",
+      "end_date": "Moment",
+      "start_date": "Option<Moment>",
+      "contract_hash": "Hash",
+      "parties": "Vec<AccountId>",
+      "projects": "Vec<ProjectId>"
+    },
+    "NdaAccessRequest": {
+      "external_id": "NdaAccessRequestId",
+      "nda_external_id": "NdaId",
+      "requester": "AccountId",
+      "encrypted_payload_hash": "Hash",
+      "encrypted_payload_iv": "Text"
+    },
     "Project": {
       "is_private": "bool",
       "external_id": "ProjectId",

--- a/pallets/deip/src/types.json
+++ b/pallets/deip/src/types.json
@@ -17,12 +17,23 @@
       "parties": "Vec<AccountId>",
       "projects": "Vec<ProjectId>"
     },
+    "NdaAccessRequestStatus": {
+      "_enum": [
+        "Pending",
+        "Fulfilled",
+        "Rejected"
+      ]
+    },
     "NdaAccessRequest": {
       "external_id": "NdaAccessRequestId",
       "nda_external_id": "NdaId",
       "requester": "AccountId",
       "encrypted_payload_hash": "Hash",
-      "encrypted_payload_iv": "Text"
+      "encrypted_payload_iv": "Text",
+      "status": "NdaAccessRequestStatus",
+      "grantor": "Option<AccountId>",
+      "encrypted_payload_encryption_key": "Option<Text>",
+      "proof_of_encrypted_payload_encryption_key": "Option<Text>"
     },
     "Project": {
       "is_private": "bool",


### PR DESCRIPTION
## Key Points

### Stoage Models 
- Nda 
```rust
pub struct Nda<Hash, AccountId, Moment>  {
    contract_creator: AccountId,
    external_id: NdaId,
    end_date: Moment,
    start_date: Option<Moment>,
    contract_hash: Hash,
    parties: Vec<AccountId>,
    projects: Vec<ProjectId>,
}
```

- NdaAccessRequest
```rust
pub struct NdaAccessRequest<Hash, AccountId>  {
    external_id: NdaAccessRequestId,
    nda_external_id: NdaId,
    requester: AccountId,
    encrypted_payload_hash: Hash,
    encrypted_payload_iv: Vec<u8>,
    status: NdaAccessRequestStatus,
    grantor: Option<AccountId>,
    encrypted_payload_encryption_key: Option<Vec<u8>>,
    proof_of_encrypted_payload_encryption_key: Option<Vec<u8>>,
}
```


### Operations

- create_project_nda 
```rust
fn create_project_nda(origin,  
            external_id: NdaId,
            end_date: T::Moment,
            contract_hash: T::Hash,
            maybe_start_date: Option<T::Moment>,
            parties: Vec<T::AccountId>,
            projects: Vec<ProjectId>
        )
```
- create_nda_content_access_request
```rust
fn create_nda_content_access_request(
            origin, 
            external_id: NdaAccessRequestId,
            nda_external_id: NdaId,
            encrypted_payload_hash: T::Hash,
            encrypted_payload_iv: Vec<u8>,
        ) 
```
- fulfill_nda_content_access_request 
```rust
fn fulfill_nda_content_access_request(
            origin, 
            external_id: NdaAccessRequestId,
            encrypted_payload_encryption_key: Vec<u8>,
            proof_of_encrypted_payload_encryption_key: Vec<u8>,
        )
```
- reject_nda_content_access_request
```rust
fn reject_nda_content_access_request(
             origin, 
             external_id: NdaAccessRequestId,
         )
```