### PR TITLE
implement HasCompact for H160

### DIFF
--- a/pallets/deip/src/types.json
+++ b/pallets/deip/src/types.json
@@ -221,5 +221,11 @@
     "is_frozen": "bool"
   },
   "DeipProjectIdOf": "H160",
-  "AssetsAssetIdOf": "u32"
+  "AssetId": {
+    "0": "H160"
+  },
+  "AssetsAssetIdOf": "AssetId",
+  "Compact<AssetId>": {
+    "0": "AssetId"
+  }
 }

--- a/runtime/src/compact_h160.rs
+++ b/runtime/src/compact_h160.rs
@@ -1,0 +1,93 @@
+use sp_std::vec::Vec;
+
+// for details please check parity_scale_codec/src/compact.rs
+
+#[derive(Default, Clone, Copy, sp_runtime::RuntimeDebug, PartialEq, Eq, codec::Encode, codec::Decode)]
+pub struct H160(sp_core::H160);
+
+#[derive(Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
+pub struct Compact<T>(pub T);
+
+impl From<Compact<H160>> for H160 {
+    fn from(x: Compact<H160>) -> Self {
+        H160(x.0 .0)
+    }
+}
+
+impl From<H160> for Compact<H160> {
+    fn from(x: H160) -> Self {
+        Compact(x)
+    }
+}
+
+impl<'a> From<&'a H160> for Compact<H160> {
+    fn from(x: &'a H160) -> Self {
+        Compact(*x)
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Copy)]
+pub struct CompactRef<'a, T>(pub &'a T);
+
+impl<'a> From<&'a Compact<H160>> for CompactRef<'a, H160> {
+    fn from(x: &'a Compact<H160>) -> Self {
+        CompactRef(&x.0)
+    }
+}
+
+impl<'a> From<&'a H160> for CompactRef<'a, H160> {
+    fn from(x: &'a H160) -> Self {
+        CompactRef(x)
+    }
+}
+
+impl codec::EncodeLike for Compact<H160> where for<'a> CompactRef<'a, H160>: codec::Encode {}
+
+impl codec::Encode for Compact<H160>
+where
+    for<'a> CompactRef<'a, H160>: codec::Encode,
+{
+    fn size_hint(&self) -> usize {
+        CompactRef::<H160>(&self.0).size_hint()
+    }
+
+    fn encode_to<W: codec::Output + ?Sized>(&self, dest: &mut W) {
+        CompactRef::<H160>(&self.0).encode_to(dest)
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        CompactRef::<H160>(&self.0).encode()
+    }
+
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        CompactRef::<H160>(&self.0).using_encoded(f)
+    }
+}
+
+impl<'a> codec::EncodeAsRef<'a, H160> for Compact<H160>
+where
+    CompactRef<'a, H160>: codec::Encode + From<&'a H160>,
+{
+    type RefType = CompactRef<'a, H160>;
+}
+
+impl<'a> codec::Encode for CompactRef<'a, H160> {
+    fn size_hint(&self) -> usize {
+        <[u8; 20] as codec::Encode>::size_hint(&self.0 .0 .0)
+    }
+
+    fn encode_to<W: codec::Output + ?Sized>(&self, dest: &mut W) {
+        <[u8; 20] as codec::Encode>::encode_to(&self.0 .0 .0, dest)
+    }
+}
+
+impl codec::Decode for Compact<H160> {
+    fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+        let array = <[u8; 20] as codec::Decode>::decode(input)?;
+        Ok(Compact::<H160>(H160(sp_core::H160(array))))
+    }
+}
+
+impl codec::HasCompact for H160 {
+    type Type = Compact<H160>;
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -51,6 +51,8 @@ pub mod app_tag_ext;
 
 pub mod deip_account;
 
+mod compact_h160;
+
 /// Import the template pallet.
 pub use pallet_template;
 // use frame_benchmarking::frame_support::pallet_prelude::Get;
@@ -80,6 +82,8 @@ pub type Hash = sp_core::H256;
 
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
+
+pub type AssetId = compact_h160::H160;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -279,7 +283,7 @@ impl pallet_template::Config for Runtime {
 
 impl pallet_deip::traits::DeipAssetSystem<AccountId> for Runtime {
 	type Balance = u64;
-	type AssetId = u32;
+	type AssetId = AssetId;
 
 	fn try_get_tokenized_project(id: &Self::AssetId) -> Option<ProjectId> {
 		DeipAssets::try_get_tokenized_project(id)
@@ -375,7 +379,7 @@ parameter_types! {
 impl pallet_assets::Config for Runtime {
 	type Event = Event;
 	type Balance = u64;
-	type AssetId = u32;
+	type AssetId = AssetId;
 	type Currency = Balances;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type AssetDepositBase = AssetDepositBase;


### PR DESCRIPTION
However H160 is encoded/decoded using base fixed length encoding. This
is intentionally 'cause H160 contains some hash and in most cases the
hash will not start with leading zeros. The latter means that in compact
encoding (if it'd be used) H160 uses 21 bytes. This is comparable to
using fixed length encoding.